### PR TITLE
Allow one to override table's CSS class

### DIFF
--- a/cruditor/templates/cruditor/includes/table.html
+++ b/cruditor/templates/cruditor/includes/table.html
@@ -10,10 +10,10 @@
 	{% endblock %}
 	{% block table %}
 		<div class="cruditor-table">
-			<table class="table"{% if table.attrs %} {{ table.attrs.as_html }}{% endif %}>
+			<table {% render_attrs table.attrs class="table" %}>
 			{% block table.thead %}
 				{% if table.show_header %}
-					<thead class="thead-light">
+					<thead {% render_attrs table.attrs.thead class="thead-light" %}>
 						<tr>
 							{% for column in table.columns %}
 								{% if column.orderable %}


### PR DESCRIPTION
It makes use of [`render_attrs`](https://github.com/jieter/django-tables2/blob/v2.0.5/django_tables2/templatetags/django_tables2.py#L278) tag to output the `<table>` and `<thead>` attributes which will allow one to override the CSS class. The upstream template for bootstrap4 already use it for `<table>`, see [here](https://github.com/jieter/django-tables2/blob/v2.0.5/django_tables2/templates/django_tables2/bootstrap4.html#L6).