### PR TITLE
Enhancement and fixes to table template

### DIFF
--- a/cruditor/templates/cruditor/includes/table.html
+++ b/cruditor/templates/cruditor/includes/table.html
@@ -25,17 +25,6 @@
 				</thead>
 			{% endif %}
 		{% endblock %}
-		{% block table.tfoot %}
-			{% if table.has_footer %}
-				<tfoot>
-					<tr>
-						{% for column in table.columns %}
-							<td {{ column.attrs.tf.as_html }}>{{ column.footer }}</td>
-						{% endfor %}
-					</tr>
-				</tfoot>
-			{% endif %}
-		{% endblock %}
 		{% block table.tbody %}
 			<tbody>
 				{% for row in table.page.object_list|default:table.rows %}
@@ -63,6 +52,17 @@
 					{% endblock %}
 				{% endfor %}
 			</tbody>
+		{% endblock %}
+		{% block table.tfoot %}
+			{% if table.has_footer %}
+				<tfoot>
+					<tr>
+						{% for column in table.columns %}
+							<td {{ column.attrs.tf.as_html }}>{{ column.footer }}</td>
+						{% endfor %}
+					</tr>
+				</tfoot>
+			{% endif %}
 		{% endblock %}
 		</table>
 	{% endblock %}

--- a/cruditor/templates/cruditor/includes/table.html
+++ b/cruditor/templates/cruditor/includes/table.html
@@ -10,10 +10,10 @@
 	{% endblock %}
 	{% block table %}
 		<div class="cruditor-table">
-			<table class="table"{% if table.attrs %} {{ table.attrs.as_html }}{% endif %}>
+			<table {% render_attrs table.attrs class="table" %}>
 			{% block table.thead %}
 				{% if table.show_header %}
-					<thead class="thead-light">
+					<thead {% render_attrs table.attrs.thead class="thead-light" %}>
 						<tr>
 							{% for column in table.columns %}
 								{% if column.orderable %}

--- a/cruditor/templates/cruditor/includes/table.html
+++ b/cruditor/templates/cruditor/includes/table.html
@@ -26,7 +26,7 @@
 			{% endif %}
 		{% endblock %}
 		{% block table.tbody %}
-			<tbody>
+			<tbody{% if table.attrs.tbody %} {{ table.attrs.tbody.as_html }}{% endif %}>
 				{% for row in table.page.object_list|default:table.rows %}
 					{% block table.tbody.row %}
 						<tr {{ row.attrs.as_html }}>
@@ -55,7 +55,7 @@
 		{% endblock %}
 		{% block table.tfoot %}
 			{% if table.has_footer %}
-				<tfoot>
+				<tfoot{% if table.attrs.tfoot %} {{ table.attrs.tfoot.as_html }}{% endif %}>
 					<tr>
 						{% for column in table.columns %}
 							<td {{ column.attrs.tf.as_html }}>{{ column.footer }}</td>

--- a/cruditor/templates/cruditor/includes/table.html
+++ b/cruditor/templates/cruditor/includes/table.html
@@ -9,62 +9,61 @@
 		{% endif %}
 	{% endblock %}
 	{% block table %}
-		<div class="cruditor-table">
-			<table {% render_attrs table.attrs class="table" %}>
-			{% block table.thead %}
-				{% if table.show_header %}
-					<thead {% render_attrs table.attrs.thead class="thead-light" %}>
-						<tr>
-							{% for column in table.columns %}
-								{% if column.orderable %}
-									<th {{ column.attrs.th.as_html }} scope="col"><a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a></th>
+		<table {% render_attrs table.attrs class="table" %}>
+		{% block table.thead %}
+			{% if table.show_header %}
+				<thead {% render_attrs table.attrs.thead class="thead-light" %}>
+					<tr>
+						{% for column in table.columns %}
+							{% if column.orderable %}
+								<th {{ column.attrs.th.as_html }} scope="col"><a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a></th>
+							{% else %}
+								<th {{ column.attrs.th.as_html }} scope="col">{{ column.header }}</th>
+							{% endif %}
+						{% endfor %}
+					</tr>
+				</thead>
+			{% endif %}
+		{% endblock %}
+		{% block table.tfoot %}
+			{% if table.has_footer %}
+				<tfoot>
+					<tr>
+						{% for column in table.columns %}
+							<td {{ column.attrs.tf.as_html }}>{{ column.footer }}</td>
+						{% endfor %}
+					</tr>
+				</tfoot>
+			{% endif %}
+		{% endblock %}
+		{% block table.tbody %}
+			<tbody>
+				{% for row in table.page.object_list|default:table.rows %}
+					{% block table.tbody.row %}
+						<tr {{ row.attrs.as_html }}>
+							{% for column, cell in row.items %}
+								{% if forloop.first %}
+									<th scope="row" {{ column.attrs.td.as_html }}>
 								{% else %}
-									<th {{ column.attrs.th.as_html }} scope="col">{{ column.header }}</th>
+									<td {{ column.attrs.td.as_html }}>
+								{% endif %}
+								{% if column.localize == None %}{{ cell }}{% else %}{% if column.localize %}{{ cell|localize }}{% else %}{{ cell|unlocalize }}{% endif %}{% endif %}
+								{% if forloop.first %}
+									</th>
+								{% else %}
+									</td>
 								{% endif %}
 							{% endfor %}
 						</tr>
-					</thead>
-				{% endif %}
-			{% endblock %}
-			{% block table.tfoot %}
-				{% if table.has_footer %}
-					<tfoot>
-						<tr>
-							{% for column in table.columns %}
-								<td {{ column.attrs.tf.as_html }}>{{ column.footer }}</td>
-							{% endfor %}
-						</tr>
-					</tfoot>
-				{% endif %}
-			{% endblock %}
-			{% block table.tbody %}
-				<tbody>
-					{% for row in table.page.object_list|default:table.rows %}
-						{% block table.tbody.row %}
-							<tr {{ row.attrs.as_html }}>
-								{% for column, cell in row.items %}
-									{% if forloop.first %}
-										<th scope="row" {{ column.attrs.td.as_html }}>
-									{% else %}
-										<td {{ column.attrs.td.as_html }}>
-									{% endif %}
-									{% if column.localize == None %}{{ cell }}{% else %}{% if column.localize %}{{ cell|localize }}{% else %}{{ cell|unlocalize }}{% endif %}{% endif %}
-									{% if forloop.first %}
-										</th>
-									{% else %}
-										</td>
-									{% endif %}
-								{% endfor %}
-							</tr>
-						{% endblock %}
-					{% empty %}
-						{% block table.tbody.empty_text %}
-							{% trans 'No data available.' as default_table_empty_text %}
-							<tr><td colspan="{{ table.columns|length }}">{{ table.empty_text|default:default_table_empty_text }}</td></tr>
-						{% endblock %}
-					{% endfor %}
-				</tbody>
-			{% endblock %}
+					{% endblock %}
+				{% empty %}
+					{% block table.tbody.empty_text %}
+						{% trans 'No data available.' as default_table_empty_text %}
+						<tr><td colspan="{{ table.columns|length }}">{{ table.empty_text|default:default_table_empty_text }}</td></tr>
+					{% endblock %}
+				{% endfor %}
+			</tbody>
+		{% endblock %}
 		</table>
 	{% endblock %}
 	{% block table.pagination.bottom %}


### PR DESCRIPTION
As it's only related to the table template, here is an all-in-one PR but tell me if you prefer to split them.

## Enhancements
* **Allow one to override `<table>` and `<thead>` CSS classes** (replace #6) [f2210e4]
  It makes use of [`render_attrs`](https://github.com/jieter/django-tables2/blob/v2.0.5/django_tables2/templatetags/django_tables2.py#L278) tag to output the `<table>` and `<thead>` attributes which will allow one to override the CSS class. The upstream template for bootstrap4 already use it for `<table>`, see [here](https://github.com/jieter/django-tables2/blob/v2.0.5/django_tables2/templates/django_tables2/bootstrap4.html#L6).
* Output `<tbody>` and `<tfoot>` attributes if they are defined [ae9444b]

## Fixes
* Remove unclosed and duplicated `<div.cruditor-table>` tag [8c2c723]
* Move `<tfoot>` to the bottom of the table [a7109b8]