### PR TITLE
Remove the need to check the box to delete the item

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+1.3.0 - UNRELEASED
+------------------
+
+* Catch the exception and show an error message when deleting an item with
+  protected related objects
+* Remove ``DeleteConfirmForm`` to replace the checkbox by a simple message and
+  make the deletion process lighter
+
+
 1.2.1 - 2019-03-26
 ------------------
 

--- a/cruditor/forms.py
+++ b/cruditor/forms.py
@@ -2,7 +2,6 @@ from django import forms
 from django.contrib.auth.forms import AuthenticationForm, SetPasswordForm
 from django.forms.formsets import DELETION_FIELD_NAME
 from django.utils.translation import ugettext
-from django.utils.translation import ugettext_lazy as _
 from tapeforms.contrib.bootstrap import BootstrapTapeformMixin
 
 
@@ -76,11 +75,3 @@ class ChangePasswordForm(CruditorTapeformMixin, SetPasswordForm):
     Tapeform-enabled version of the Django SetPasswordForm.
     """
     pass
-
-
-class DeleteConfirmForm(CruditorTapeformMixin, forms.Form):
-    """
-    Cruditor form for delete confirmations. Used in CruditorDeleteView.
-    """
-    confirm = forms.BooleanField(
-        label=_('Are you sure you want to delete this item?'), required=True)

--- a/cruditor/templates/cruditor/delete.html
+++ b/cruditor/templates/cruditor/delete.html
@@ -1,8 +1,8 @@
-{% extends 'cruditor/form.html' %}
+{% extends 'cruditor/base.html' %}
 {% load i18n %}
 
 
-{% block form %}
+{% block content %}
 	{% if linked_objects %}
 		<div class="alert alert-danger">{% trans "Unable to delete this item." %}</div>
 		<p>{% blocktrans %}This item is currently referenced by other objects, and cannot be deleted without jeopardising data integrity. To delete it successfully, first remove references from the following objects, then try again:{% endblocktrans %}</p>
@@ -12,14 +12,31 @@
 			{% endfor %}
 		</ul>
 	{% else %}
-		{{ block.super }}
-	{% endif %}
-{% endblock %}
+		<div class="cruditor-form">
+			<form action="." method="post">
+				{% csrf_token %}
 
+				{% block form %}
+					<p>{% trans 'Are you sure you want to delete this item?' %}</p>
+				{% endblock %}
 
-{% block form_actions %}
-	{# The submit button is removed if there are protected related objects. #}
-	{% if not linked_objects %}
-		{{ block.super }}
+				{% block form_actions %}
+					<div class="row form-actions">
+						<div class="col-auto mr-auto">
+							{% block form_actions_left %}
+							{% endblock %}
+						</div>
+						<div class="col-auto">
+							{% block form_actions_right %}
+								<button class="btn btn-primary" type="submit" name="save">
+									{% trans 'Confirm deletion' as default_form_save_button_label %}
+									{{ form_save_button_label|default:default_form_save_button_label }}
+								</button>
+							{% endblock %}
+						</div>
+					</div>
+				{% endblock %}
+			</form>
+		</div>
 	{% endif %}
 {% endblock %}

--- a/examples/collection/views.py
+++ b/examples/collection/views.py
@@ -45,3 +45,8 @@ class PersonChangeView(PersonViewMixin, CruditorChangeView):
 
 class PersonDeleteView(PersonViewMixin, CruditorDeleteView):
     success_url = reverse_lazy('collection:list')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['form_save_button_label'] = 'Delete this person'
+        return context

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -235,37 +235,31 @@ class TestDeleteView:
 
         assert Person.objects.exists() is True
 
-    def test_post_valid(self, admin_client):
+    def test_post(self, admin_client):
         response = admin_client.post(
-            reverse('collection:delete', args=(self.person.pk,)),
-            data={'confirm': '1'}
-        )
+            reverse('collection:delete', args=(self.person.pk,)))
         assert response.status_code == 302
         assert response['Location'] == reverse('collection:list')
 
         assert Person.objects.exists() is False
 
-    def test_post_invalid(self, admin_client):
-        response = admin_client.post(
-            reverse('collection:delete', args=(self.person.pk,)), data={})
-        assert response.status_code == 200
-        assert response.context['form'].is_valid() is False
-
-        assert Person.objects.exists() is True
-
     def test_post_protected(self, admin_client):
         related = RelatedPersonFactory(person=self.person)
 
         response = admin_client.post(
-            reverse('collection:delete', args=(self.person.pk,)),
-            data={'confirm': '1'}
-        )
+            reverse('collection:delete', args=(self.person.pk,)))
         assert response.status_code == 200
         assert response.context['linked_objects'] == [
             'Related person: {}'.format(str(related)),
         ]
 
         assert Person.objects.exists() is True
+
+    def test_custom_button_label(self, admin_client):
+        response = admin_client.get(
+            reverse('collection:delete', args=(self.person.pk,)))
+        assert response.context['form_save_button_label'] == 'Delete this person'
+        assert 'Delete this person' in response.content.decode(response.charset)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This is a proposal to simplify the process of an item deletion, closest to the way it is done in the Django admin.

It just removes the need to check the box to confirm the deletion of the item. As it is already a separate view which requires to click on a button to actually delete the item, it removes one confirmation step for the user. Thus, the form is removed and the view is now based on [`DeleteView`](https://docs.djangoproject.com/en/stable/ref/class-based-views/generic-editing/#django.views.generic.edit.DeleteView). To keep the same overridable methods - e.g. `perform_delete()`, the `delete()` method is override.

What do you think? I am also wondering if it could be great to have a "Cancel" button...