### PR TITLE
Allow success message to be totally customized

### DIFF
--- a/cruditor/mixins.py
+++ b/cruditor/mixins.py
@@ -285,6 +285,13 @@ class FormViewMixin(object):
             formset.instance = self.object
             self.formset_objects[formset_name] = formset.save()
 
+    def get_success_message(self):
+        """
+        Returns the success message to display when the form is valid.
+        """
+        return self.success_message.format(
+            model=self.get_model_verbose_name(), object=self.object)
+
     def form_valid(self, form, **formsets):
         """
         Saves the data and provides a nice success message, then redirects to the
@@ -292,8 +299,7 @@ class FormViewMixin(object):
         """
         self.save_form(form, **formsets)
 
-        messages.success(self.request, self.success_message.format(
-            model=self.get_model_verbose_name(), object=self.object))
+        messages.success(self.request, self.get_success_message())
 
         return redirect(self.get_success_url())
 

--- a/examples/collection/views.py
+++ b/examples/collection/views.py
@@ -42,6 +42,9 @@ class PersonChangeView(PersonViewMixin, CruditorChangeView):
     def get_delete_url(self):
         return reverse('collection:delete', args=(self.object.pk,))
 
+    def get_success_message(self):
+        return None
+
 
 class PersonDeleteView(PersonViewMixin, CruditorDeleteView):
     success_url = reverse_lazy('collection:list')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,7 @@
 import pytest
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages import SUCCESS as SUCCESS_LEVEL
+from django.contrib.messages import get_messages
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.urls import reverse
 
@@ -173,6 +175,10 @@ class TestAddView:
         assert response.status_code == 302
         assert response['Location'] == reverse('collection:list')
 
+        messages = list(get_messages(response.wsgi_request))
+        assert len(messages) == 1
+        assert messages[0].level == SUCCESS_LEVEL
+
         assert Person.objects.get().first_name == 'John'
 
     def test_post_invalid(self, admin_client):
@@ -210,6 +216,9 @@ class TestChangeView:
         assert response.status_code == 302
         assert response['Location'] == reverse('collection:list')
 
+        messages = list(get_messages(response.wsgi_request))
+        assert len(messages) == 0
+
         self.person.refresh_from_db()
         assert self.person.first_name == 'John'
 
@@ -240,6 +249,10 @@ class TestDeleteView:
             reverse('collection:delete', args=(self.person.pk,)))
         assert response.status_code == 302
         assert response['Location'] == reverse('collection:list')
+
+        messages = list(get_messages(response.wsgi_request))
+        assert len(messages) == 1
+        assert messages[0].level == SUCCESS_LEVEL
 
         assert Person.objects.exists() is False
 


### PR DESCRIPTION
It gives more control on the success message string and format. It also allow one to not add it - e.g. by returning `None`.