### PR TITLE
fix success message in CruditorDeleteView delete-method

### DIFF
--- a/cruditor/views.py
+++ b/cruditor/views.py
@@ -248,12 +248,7 @@ class CruditorDeleteView(CruditorMixin, DeleteView):
                     linked_objects=self.format_linked_objects(e.protected_objects)
                 )
             )
-        messages.success(
-            self.request,
-            self.success_message.format(
-                model=self.get_model_verbose_name(), object=self.object
-            ),
-        )
+        messages.success(self.request, self.get_success_message())
         return HttpResponseRedirect(self.get_success_url())
 
     def get_title(self):


### PR DESCRIPTION
In the CruditorDeleteView we access directly `self.success_message`. So I changes it to use the given method `self.get_success_message()`